### PR TITLE
Extend `PathExt::pe_readdir` to return `PathReadDir`.

### DIFF
--- a/src/direntry.rs
+++ b/src/direntry.rs
@@ -1,0 +1,67 @@
+use crate::PathMetadata;
+use error_annotation::AnnotateResult;
+use std::ffi::OsString;
+use std::fs::{DirEntry, FileType};
+use std::io::Result;
+use std::path::{Path, PathBuf};
+
+/// A [DirEntry] with the originating [Path] for improved error messages.
+///
+/// This enables [std::io::Error] results to be annotated with the offending path.
+#[derive(Debug)]
+pub struct PathDirEntry<'a> {
+    dirpath: &'a Path,
+    de: DirEntry,
+}
+
+impl<'a> PathDirEntry<'a> {
+    pub fn new(dirpath: &'a Path, de: DirEntry) -> Self {
+        PathDirEntry { dirpath, de }
+    }
+
+    /// Access containing directories associated [Path].
+    pub fn dir_path(&'a self) -> &'a Path {
+        self.dirpath
+    }
+
+    /// Access associated [DirEntry].
+    pub fn direntry(&self) -> &DirEntry {
+        &self.de
+    }
+
+    /// Unwrap the underlying [DirEntry].
+    pub fn unwrap(self) -> DirEntry {
+        self.de
+    }
+
+    /// Return the [PathBuf] corresponding to this entry.
+    pub fn path(&self) -> PathBuf {
+        self.de.path()
+    }
+
+    /// Return the [PathMetadata] for this entry, annotating errors with the containing directory.
+    ///
+    /// The returned [PathMetadata] when successfully loaded is associated with the path within the
+    /// directory.
+    pub fn metadata(&self) -> Result<PathMetadata> {
+        let metadata = self
+            .de
+            .metadata()
+            .annotate_err_into("parent-dir", || self.dirpath.display())?;
+
+        Ok(PathMetadata::new(self.path(), metadata))
+    }
+
+    /// Return the [FileType] for this entry, annotating any errors with the entry's path.
+    pub fn file_type(&self) -> Result<FileType> {
+        self.de
+            .file_type()
+            .annotate_err_into("path", || self.path().display().to_string())
+    }
+
+    /// Returns the bare file name of this directory entry without any other leading path
+    /// component.
+    pub fn file_name(&self) -> OsString {
+        self.de.file_name()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,15 @@
+use std::io::{Error, ErrorKind::Other};
+
+pub(crate) fn other_error(msg: String) -> Error {
+    Error::new(Other, msg)
+}
+
+macro_rules! other_error_fmt {
+    ( $tmpl:expr ) => {
+        crate::other_error($tmpl.to_string())
+    };
+
+    ( $tmpl:expr, $( $a:expr ),* $(,)? ) => {
+        crate::other_error(format!($tmpl, $( $a ),* ))
+    }
+}

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -1,0 +1,24 @@
+use std::fs::FileType;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FileTypeEnum {
+    Dir,
+    File,
+    Symlink,
+}
+
+impl From<FileType> for FileTypeEnum {
+    fn from(ftype: FileType) -> Self {
+        use FileTypeEnum::*;
+
+        if ftype.is_dir() {
+            Dir
+        } else if ftype.is_file() {
+            File
+        } else if ftype.is_symlink() {
+            Symlink
+        } else {
+            unreachable!("Incoherent {:?}", ftype);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,21 @@
 //! Provides a [PathExt] trait and impl for [std::path::Path] where error descriptions include the
 //! offending path and other diagnostic information.
+
+#[macro_use]
+mod error;
+
+mod direntry;
+mod filetype;
 mod metadata;
 mod pathext;
 mod pathimpl;
 mod privtrait;
+mod readdir;
 
+pub use self::direntry::PathDirEntry;
+pub use self::filetype::FileTypeEnum;
 pub use self::metadata::PathMetadata;
 pub use self::pathext::PathExt;
+pub use self::readdir::PathReadDir;
+
+use self::error::other_error;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,27 +1,34 @@
 use error_annotation::AnnotateResult;
+use std::borrow::Cow;
 use std::fs::{FileType, Metadata, Permissions};
 use std::io::Result;
 use std::path::Path;
 use std::time::SystemTime;
 
-/// Extend [Metadata] with the originating [std::path::Path] for improved errors.
+/// Extend [Metadata] with the originating [Path] for improved error messages.
 ///
 /// This enables [std::io::Error] results to be annotated with the offending path.
 #[derive(Debug)]
 pub struct PathMetadata<'a> {
-    path: &'a Path,
+    path: Cow<'a, Path>,
     md: Metadata,
 }
 
 impl<'a> PathMetadata<'a> {
     /// Create a new `PathMetadata`.
-    pub fn new(path: &'a Path, md: Metadata) -> Self {
+    pub fn new<P>(path: P, md: Metadata) -> Self
+    where
+        Cow<'a, Path>: From<P>,
+    {
+        let path = Cow::from(path);
         PathMetadata { path, md }
     }
 
-    /// Access associated [std::path::Path].
+    /// Access associated [Path].
     pub fn path(&'a self) -> &'a Path {
-        self.path
+        use std::borrow::Borrow;
+
+        self.path.borrow()
     }
 
     /// Access associated [Metadata].

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -99,6 +99,26 @@ impl<'a> PathMetadata<'a> {
     }
 
     /// Return an error if the filetype does not match the expectation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pathutil::{PathExt, FileTypeEnum::File};
+    ///
+    /// let pb = std::path::Path::new("/");
+    /// let md = pb.pe_metadata().unwrap();
+    ///
+    /// let res = md.require_file_type(File);
+    /// assert!(res.is_err());
+    ///
+    /// let errstr = res.err().unwrap().to_string();
+    /// assert_eq!(&errstr, "
+    ///
+    /// found Dir, expected File
+    /// -with path: /
+    ///
+    /// ".trim());
+    /// ```
     pub fn require_file_type<T>(&self, expected: T) -> Result<()>
     where
         FileTypeEnum: From<T>,
@@ -109,6 +129,7 @@ impl<'a> PathMetadata<'a> {
             Ok(())
         } else {
             Err(other_error_fmt!("found {:?}, expected {:?}", found, expfte))
+                .annotate_err_into("path", || self.path.display())
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,3 +1,4 @@
+use crate::FileTypeEnum;
 use error_annotation::AnnotateResult;
 use std::borrow::Cow;
 use std::fs::{FileType, Metadata, Permissions};
@@ -95,5 +96,19 @@ impl<'a> PathMetadata<'a> {
         self.md
             .created()
             .annotate_err_into("path", || self.path.display())
+    }
+
+    /// Return an error if the filetype does not match the expectation.
+    pub fn require_file_type<T>(&self, expected: T) -> Result<()>
+    where
+        FileTypeEnum: From<T>,
+    {
+        let expfte: FileTypeEnum = expected.into();
+        let found: FileTypeEnum = self.file_type().into();
+        if found == expfte {
+            Ok(())
+        } else {
+            Err(other_error_fmt!("found {:?}, expected {:?}", found, expfte))
+        }
     }
 }

--- a/src/pathext.rs
+++ b/src/pathext.rs
@@ -1,8 +1,7 @@
 use crate::privtrait::PathExtPriv;
-use crate::PathMetadata;
+use crate::{PathDirEntry, PathMetadata, PathReadDir};
 use indoc::indoc;
 use std::ffi::OsStr;
-use std::fs::{DirEntry, ReadDir};
 use std::io::Result;
 use std::path::{Path, PathBuf};
 
@@ -358,10 +357,10 @@ pub trait PathExt: AsRef<Path> + PathExtPriv {
     ///
     /// ".trim());
     /// ```
-    fn pe_read_dir(&self) -> Result<ReadDir>;
+    fn pe_read_dir(&self) -> Result<PathReadDir>;
 
     /// Read the directory, collecting the entries, or return an error.
-    fn pe_read_dir_entries(&self) -> Result<Vec<DirEntry>> {
+    fn pe_read_dir_entries(&self) -> Result<Vec<PathDirEntry>> {
         self.pe_read_dir()?.collect()
     }
 }

--- a/src/pathimpl.rs
+++ b/src/pathimpl.rs
@@ -1,8 +1,7 @@
 use crate::privtrait::PathExtPriv;
-use crate::{PathExt, PathMetadata};
+use crate::{PathExt, PathMetadata, PathReadDir};
 use error_annotation::AnnotateResult;
 use std::ffi::OsStr;
-use std::fs::ReadDir;
 use std::io::Result;
 use std::path::{Path, PathBuf};
 
@@ -66,7 +65,9 @@ impl PathExt for Path {
             .annotate_err_into("path", || self.display())
     }
 
-    fn pe_read_dir(&self) -> Result<ReadDir> {
-        self.read_dir().annotate_err_into("path", || self.display())
+    fn pe_read_dir(&self) -> Result<PathReadDir> {
+        self.read_dir()
+            .map(|rd| PathReadDir::new(self, rd))
+            .annotate_err_into("path", || self.display())
     }
 }

--- a/src/pathimpl.rs
+++ b/src/pathimpl.rs
@@ -3,7 +3,7 @@ use crate::{PathExt, PathMetadata};
 use error_annotation::AnnotateResult;
 use std::ffi::OsStr;
 use std::fs::ReadDir;
-use std::io::{Error, ErrorKind::Other, Result};
+use std::io::Result;
 use std::path::{Path, PathBuf};
 
 impl PathExtPriv for Path {
@@ -31,7 +31,7 @@ impl PathExt for Path {
     {
         let bref = base.as_ref();
         self.strip_prefix(bref)
-            .map_err(|_| Error::new(Other, "prefix mismatch"))
+            .map_err(|_| other_error_fmt!("prefix mismatch"))
             .annotate_err_into("prefix", || bref.display())
             .annotate_err_into("path", || self.display())
     }

--- a/src/privtrait.rs
+++ b/src/privtrait.rs
@@ -1,12 +1,13 @@
+use crate::other_error;
 use error_annotation::AnnotateResult;
-use std::io::{Error, ErrorKind::Other, Result};
+use std::io::Result;
 
 /// A pub-in-priv trait for helper methods.
 pub trait PathExtPriv {
     fn pep_display(&self) -> std::path::Display;
 
     fn o2r<T>(&self, opt: Option<T>, errordesc: &str) -> Result<T> {
-        opt.ok_or_else(|| Error::new(Other, errordesc.to_string()))
+        opt.ok_or_else(|| other_error(errordesc.to_string()))
             .annotate_err_into("path", || self.pep_display())
     }
 }

--- a/src/readdir.rs
+++ b/src/readdir.rs
@@ -1,0 +1,46 @@
+use crate::PathDirEntry;
+use error_annotation::AnnotateResult;
+use std::fs::ReadDir;
+use std::io::Result;
+use std::path::Path;
+
+/// A [ReadDir] with the originating [Path] for improved error messages.
+///
+/// This enables [std::io::Error] results to be annotated with the offending path.
+#[derive(Debug)]
+pub struct PathReadDir<'a> {
+    path: &'a Path,
+    rd: ReadDir,
+}
+
+impl<'a> PathReadDir<'a> {
+    pub fn new(path: &'a Path, rd: ReadDir) -> Self {
+        PathReadDir { path, rd }
+    }
+
+    /// Access associated [Path].
+    pub fn path(&'a self) -> &'a Path {
+        self.path
+    }
+
+    /// Access associated [ReadDir].
+    pub fn readdir(&self) -> &ReadDir {
+        &self.rd
+    }
+
+    /// Unwrap the underlying [ReadDir].
+    pub fn unwrap(self) -> ReadDir {
+        self.rd
+    }
+}
+
+impl<'a> Iterator for PathReadDir<'a> {
+    type Item = Result<PathDirEntry<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.rd.next().map(|de| {
+            de.annotate_err_into("path", || self.path.display())
+                .map(|de| PathDirEntry::new(self.path, de))
+        })
+    }
+}


### PR DESCRIPTION
This tracks paths while reading directories such that errors are annotated with the appropriate offending path.